### PR TITLE
ci: pin pnpm to v10 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
         with:
+          version: 10
           run_install: false
 
       - name: Install Node.js


### PR DESCRIPTION
## Summary
- Pins `pnpm/action-setup` to `version: 10` in `.github/workflows/publish.yml`
- Fixes broken npm publish on tag (last two releases v1.3.11, v1.3.12 failed with `ENEEDAUTH`)

## Root cause
`pnpm/action-setup` v6.0.3+ began installing **pnpm v11.0.0-rc.5** as the global PATH shim. The `pnpm publish` step picked up the prerelease (instead of the `packageManager` field pinned in `package.json`), and that RC fails npm Trusted Publishing OIDC auth — npm sees no token and rejects with `ENEEDAUTH`.

Pinning `version: 10` keeps the global shim on stable pnpm v10 and restores the OIDC/`--provenance` flow that worked through v1.3.10.

## Test plan
- [ ] Merge, then push a patch tag (e.g. v1.3.13) and confirm the `Publish to NPM` job succeeds and the npm provenance statement is logged